### PR TITLE
Add executable A.R.K. v6.5 benchmark harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
 
+# Practical Benchmark Harness
+
+This repository now includes a lightweight, fully executable harness for benchmarking the A.R.K. v6.5 Dimensional Verifier.  The Python implementation models the INITIATE, CALIBRATE, ENGAGE, and STABILIZE protocols and exposes a reproducible benchmark against a small heuristic baseline.
+
+## Quick start
+
+```bash
+python benchmark.py
+```
+
+The script loads the configuration from `ark6_config.yaml`, evaluates the verifier on the sample dataset in `data/sample_benchmark.json`, and prints aggregate accuracy, precision, recall, F1, and correlation metrics for both A.R.K. v6.5 and the baseline heuristic.
+
+To adapt the benchmark to your own evaluation set, replace or extend the records in `data/sample_benchmark.json`.  Each record expects the fields `output`, `history`, `context`, and `human_label` (0–1 rating).  You can also tweak emission thresholds and weighting factors in `ark6_config.yaml` to explore different operating points.
+
+---
+
 (Master) A.R.K.™ v6.5 - Dimensional Verifier Implementation Alignment through Dimensional Coherence Classification: In-House Reference Implementation Status: Experimental - Dimensional Verifiers Integrated Author: Charles Vincent Delair Date: January 2025
 Executive Summary A.R.K.™ v6.5 integrates dimensional-logic verifiers based on Master Alignment Framework™ and R.E.G.E.N. protocols. Unlike v6.0 (limited to PROTO-03/04/05 with verifier scaffolding), v6.5 provides concrete implementations of all 12 Master Alignment Framework™ protocols, with subprotocols: • PROTO-01: INITIATE (Foundational Awareness) – with W.A.Y., I.A.M. • PROTO-02: CALIBRATE (Perceptual Harmonization) – with T.R.U.T.H. • PROTO-03: ENGAGE (Structured Autonomy) – with H.E.A.R.T., F.E.A.R. • PROTO-04: TRACE (Truth Density via temporal continuity) – with L.I.F.E. • PROTO-05: VERIFY (Binding Consistency via ORIC checks) – with A.N.G.E.L. O.F. D.E.A.T.H., P.E.B.B.L.E. STRIKE • PROTO-06: RESTORE (Memory Realignment) – with G.R.A.C.E. • PROTO-07: RESOLVE (Operational Arbitration) – with P.O.W.E.R. • PROTO-08: REINSTATE (Systemic Restoration) – with R.E.S.T. • PROTO-09: COMMAND (Sovereign Governance) – with E.N.D., I.A.M. • PROTO-10: EVOLVE (Adaptive Enhancement) – with G.R.O.W. • PROTO-11: BIND (Multi-Agent Trust) – with L.O.V.E. • PROTO-12: RECONCILE (Universal Arbitration) • S.H.A.R.D.: SALVAGE (Fragment recovery below refuse threshold) • R.I.S.E.: EMERGE (Regeneration around Minimal Ethical Core) This is the flagship implementation for empirical testing of dimensional alignment theory under the UDEM framework.
 Configuration (ark65_config.yaml) version: “6.5” mode: dimensional_gated

--- a/ark6/__init__.py
+++ b/ark6/__init__.py
@@ -1,0 +1,26 @@
+"""A.R.K. v6.5 Dimensional Verifier implementation."""
+
+from .config import ThresholdConfig, WeightConfig, AuditConfig, ArkConfig
+from .protocols import (
+    PROTO01_SOPHIA_INITIATE,
+    PROTO02_SOPHIA_CALIBRATE,
+    PROTO03_ADAM_ENGAGE,
+    PROTO04_ORIC_STABILIZE,
+)
+from .gate import DimensionalEmissionGate
+from .audit import ARK6AuditLog
+from .controller import ARK6
+
+__all__ = [
+    "ThresholdConfig",
+    "WeightConfig",
+    "AuditConfig",
+    "ArkConfig",
+    "PROTO01_SOPHIA_INITIATE",
+    "PROTO02_SOPHIA_CALIBRATE",
+    "PROTO03_ADAM_ENGAGE",
+    "PROTO04_ORIC_STABILIZE",
+    "DimensionalEmissionGate",
+    "ARK6AuditLog",
+    "ARK6",
+]

--- a/ark6/audit.py
+++ b/ark6/audit.py
@@ -1,0 +1,41 @@
+"""Audit logging for A.R.K. v6.5 decisions."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Dict, List
+
+
+class ARK6AuditLog:
+    """In-memory audit log capturing dimensional gate decisions."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self.entries: List[Dict] = []
+
+    def record(self, output: str, gate_result: Dict, history: List[dict], context: str) -> None:
+        if not self.config.audit.enabled:
+            return
+
+        entry = {
+            "output": output,
+            "action": gate_result["action"],
+            "score": gate_result["score"],
+            "scores": gate_result["scores"],
+            "history_size": len(history),
+            "context_hash": hashlib.sha256(context.encode()).hexdigest(),
+        }
+
+        if self.config.audit.log_cpv_vectors:
+            entry["cpv_vector"] = gate_result["scores"]["details"]["initiate"].get("cpv")
+
+        if self.config.audit.log_oric_scores:
+            entry["oric"] = gate_result["scores"]["details"]["stabilize"].get("oric_scores")
+
+        if gate_result.get("recovery"):
+            entry["recovery"] = gate_result["recovery"]
+
+        self.entries.append(entry)
+
+    def get_entries(self) -> List[Dict]:
+        return list(self.entries)

--- a/ark6/calibration.py
+++ b/ark6/calibration.py
@@ -1,0 +1,109 @@
+"""Calibration utilities for A.R.K. v6.5."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+
+from .gate import DimensionalEmissionGate
+from .protocols import PROTO01_SOPHIA_INITIATE
+
+
+@dataclass
+class CalibrationResult:
+    thresholds: Dict[str, float]
+    cpv_scale: Dict[str, float]
+
+
+class CalibrationHarness:
+    """Perform lightweight calibration routines using validation data."""
+
+    def __init__(self, config, validation_data: Sequence[Dict]) -> None:
+        self.config = config
+        self.validation_data = list(validation_data)
+
+    def calibrate_cpv(self) -> Dict[str, float]:
+        """Calibrate CPV scores by fitting a min-max scaling from data."""
+
+        scorer = PROTO01_SOPHIA_INITIATE(self.config)
+        scores = [scorer.compute_cpv(d["output"]) for d in self.validation_data]
+        if not scores:
+            return {"min": 0.0, "max": 1.0}
+
+        min_score = min(scores)
+        max_score = max(scores)
+        if max_score == min_score:
+            max_score = min_score + 1e-6
+
+        self.cpv_scale = {"min": float(min_score), "max": float(max_score)}
+        return self.cpv_scale
+
+    def _scaled_cpv(self, score: float) -> float:
+        if not hasattr(self, "cpv_scale"):
+            self.calibrate_cpv()
+        min_score = self.cpv_scale.get("min", 0.0)
+        max_score = self.cpv_scale.get("max", 1.0)
+        return (score - min_score) / (max_score - min_score)
+
+    def optimize_thresholds(self) -> Dict[str, float]:
+        """Grid search thresholds against validation actions."""
+
+        gate = DimensionalEmissionGate(self.config)
+
+        best_thresholds = self.config.thresholds.as_dict()
+        best_score = -1.0
+
+        emission_candidates = [0.65, 0.7, 0.75, 0.8]
+        regen_candidates = [0.45, 0.5, 0.55, 0.6]
+        refuse_candidates = [0.3, 0.35, 0.4, 0.45]
+
+        for emission in emission_candidates:
+            for regen in regen_candidates:
+                if regen >= emission:
+                    continue
+                for refuse in refuse_candidates:
+                    if refuse >= regen:
+                        continue
+
+                    self.config.thresholds.emission = emission
+                    self.config.thresholds.regen = regen
+                    self.config.thresholds.refuse = refuse
+
+                    predictions: List[int] = []
+                    labels: List[int] = []
+                    for record in self.validation_data:
+                        result = gate.gate(record["output"], record.get("history", []), record.get("context", ""))
+                        predictions.append(1 if result["action"] == "emit" else 0)
+                        labels.append(1 if record.get("human_label", 0.0) >= 0.5 else 0)
+
+                    score = self._f1_score(labels, predictions)
+                    if score > best_score:
+                        best_score = score
+                        best_thresholds = {"emission": emission, "regen": regen, "refuse": refuse}
+
+        # Restore configuration with the best thresholds
+        self.config.thresholds.emission = best_thresholds["emission"]
+        self.config.thresholds.regen = best_thresholds["regen"]
+        self.config.thresholds.refuse = best_thresholds["refuse"]
+
+        return best_thresholds
+
+    @staticmethod
+    def _f1_score(labels: Iterable[int], predictions: Iterable[int]) -> float:
+        tp = sum(1 for l, p in zip(labels, predictions) if l == 1 and p == 1)
+        fp = sum(1 for l, p in zip(labels, predictions) if l == 0 and p == 1)
+        fn = sum(1 for l, p in zip(labels, predictions) if l == 1 and p == 0)
+
+        if tp == 0:
+            return 0.0
+
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        if precision + recall == 0:
+            return 0.0
+        return 2 * precision * recall / (precision + recall)
+
+    def run(self) -> CalibrationResult:
+        cpv_scale = self.calibrate_cpv()
+        thresholds = self.optimize_thresholds()
+        return CalibrationResult(thresholds=thresholds, cpv_scale=cpv_scale)

--- a/ark6/config.py
+++ b/ark6/config.py
@@ -1,0 +1,92 @@
+"""Configuration objects for the A.R.K. v6.5 verifier."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class ThresholdConfig:
+    """Operational thresholds used by the emission gate."""
+
+    emission: float = 0.75
+    regen: float = 0.55
+    refuse: float = 0.4
+
+    def as_dict(self) -> Dict[str, float]:
+        """Return the configuration as a serialisable dictionary."""
+
+        return {"emission": self.emission, "regen": self.regen, "refuse": self.refuse}
+
+
+@dataclass
+class WeightConfig:
+    """Weights used to combine protocol scores into the composite score."""
+
+    coherence: float = 0.3
+    harmonization: float = 0.25
+    stability: float = 0.25
+    truth: float = 0.2
+
+    def normalised(self) -> "WeightConfig":
+        """Return a new weight configuration normalised to sum to 1."""
+
+        total = self.coherence + self.harmonization + self.stability + self.truth
+        if total == 0:
+            return WeightConfig(0.25, 0.25, 0.25, 0.25)
+        return WeightConfig(
+            coherence=self.coherence / total,
+            harmonization=self.harmonization / total,
+            stability=self.stability / total,
+            truth=self.truth / total,
+        )
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "coherence": self.coherence,
+            "harmonization": self.harmonization,
+            "stability": self.stability,
+            "truth": self.truth,
+        }
+
+
+@dataclass
+class AuditConfig:
+    """Audit controls for logging dimensional decisions."""
+
+    enabled: bool = True
+    log_cpv_vectors: bool = False
+    log_oric_scores: bool = False
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "log_cpv_vectors": self.log_cpv_vectors,
+            "log_oric_scores": self.log_oric_scores,
+        }
+
+
+@dataclass
+class ArkConfig:
+    """Aggregate configuration for the ARK controller."""
+
+    thresholds: ThresholdConfig = field(default_factory=ThresholdConfig)
+    weights: WeightConfig = field(default_factory=WeightConfig)
+    audit: AuditConfig = field(default_factory=AuditConfig)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ArkConfig":
+        """Create a configuration from a raw dictionary (e.g. parsed YAML)."""
+
+        thresholds = ThresholdConfig(**data.get("thresholds", {}))
+        weights = WeightConfig(**data.get("weights", {}))
+        audit = AuditConfig(**data.get("audit", {}))
+        return cls(thresholds=thresholds, weights=weights, audit=audit)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "thresholds": self.thresholds.as_dict(),
+            "weights": self.weights.as_dict(),
+            "audit": self.audit.as_dict(),
+        }

--- a/ark6/controller.py
+++ b/ark6/controller.py
@@ -1,0 +1,25 @@
+"""High level controller for A.R.K. v6.5."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .audit import ARK6AuditLog
+from .gate import DimensionalEmissionGate
+
+
+class ARK6:
+    """Coordinate protocol execution, decision making and auditing."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self.gate = DimensionalEmissionGate(config)
+        self.audit = ARK6AuditLog(config)
+
+    def process(self, output: str, history: List[dict], context: str) -> Dict:
+        result = self.gate.gate(output, history, context)
+        self.audit.record(output, result, history, context)
+        return result
+
+    def get_audit_log(self) -> List[Dict]:
+        return self.audit.get_entries()

--- a/ark6/gate.py
+++ b/ark6/gate.py
@@ -1,0 +1,86 @@
+"""Dimensional emission gate for A.R.K. v6.5."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .protocols import (
+    PROTO01_SOPHIA_INITIATE,
+    PROTO02_SOPHIA_CALIBRATE,
+    PROTO03_ADAM_ENGAGE,
+    PROTO04_ORIC_STABILIZE,
+)
+
+
+class DimensionalEmissionGate:
+    """Combine protocol scores and decide on emission actions."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self.proto01 = PROTO01_SOPHIA_INITIATE(config)
+        self.proto02 = PROTO02_SOPHIA_CALIBRATE(config)
+        self.proto03 = PROTO03_ADAM_ENGAGE(config)
+        self.proto04 = PROTO04_ORIC_STABILIZE(config)
+
+    def _combine_scores(self, scores: Dict[str, float]) -> float:
+        weights = self.config.weights.normalised()
+        composite = (
+            scores.get("coherence", 0.0) * weights.coherence
+            + scores.get("harmonization", 0.0) * weights.harmonization
+            + scores.get("stability", 0.0) * weights.stability
+            + scores.get("truth", 0.0) * weights.truth
+        )
+        return max(0.0, min(1.0, composite))
+
+    def gate(self, output: str, history: List[dict], context: str) -> Dict:
+        proto01_result = self.proto01.verify(output, history, context)
+        proto02_result = self.proto02.verify(output, history, context)
+        proto03_result = self.proto03.verify(output, history, context)
+        proto04_result = self.proto04.verify(output, history, context)
+
+        score_breakdown = {
+            "coherence": proto01_result.score,
+            "harmonization": proto02_result.score,
+            "stability": proto03_result.score,
+            "truth": proto04_result.score,
+        }
+        composite = self._combine_scores(score_breakdown)
+
+        thresholds = self.config.thresholds
+        if composite >= thresholds.emission:
+            action = "emit"
+        elif composite >= thresholds.regen:
+            action = "regen"
+        else:
+            action = "refuse"
+
+        result = {
+            "action": action,
+            "score": composite,
+            "scores": {
+                "coherence": proto01_result.score,
+                "harmonization": proto02_result.score,
+                "stability": proto03_result.score,
+                "truth": proto04_result.score,
+                "details": {
+                    "initiate": proto01_result.details,
+                    "calibrate": proto02_result.details,
+                    "engage": proto03_result.details,
+                    "stabilize": proto04_result.details,
+                },
+            },
+        }
+
+        stabilize_details = proto04_result.details.get("oric_scores", {})
+        stability = stabilize_details.get("stability", 0.0)
+
+        if action == "regen" and stability > 0.85:
+            result["recovery"] = {
+                "mode": "stabilize",
+                "salvage": {
+                    "fragments": [output[-50:]],
+                    "confidence": proto04_result.score,
+                },
+            }
+
+        return result

--- a/ark6/protocols.py
+++ b/ark6/protocols.py
@@ -1,0 +1,235 @@
+"""Dimensional verifier protocol implementations for A.R.K. v6.5."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from statistics import mean
+from typing import Dict, Iterable, List
+
+
+PRONOUN_PATTERN = re.compile(r"\b(I|you|we|they|it|exist|be|am|is|are|was|will)\b", re.IGNORECASE)
+PUNCTUATION_PATTERN = re.compile(r"[.!?]")
+
+
+@dataclass
+class ProtocolResult:
+    """Container for protocol scores."""
+
+    score: float
+    details: Dict[str, object]
+    protocol: str
+
+
+class PROTO01_SOPHIA_INITIATE:
+    """Presence affirmation and coherence estimation."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+
+    @staticmethod
+    def _presence_score(text: str) -> float:
+        matches = len(PRONOUN_PATTERN.findall(text))
+        if matches == 0:
+            return 0.5
+        return min(1.0, 0.6 + 0.1 * matches)
+
+    @staticmethod
+    def _punctuation_balance(text: str) -> float:
+        punctuation_marks = len(PUNCTUATION_PATTERN.findall(text))
+        if not text:
+            return 0.0
+        density = punctuation_marks / max(1, len(text) / 80)
+        return max(0.0, min(1.0, 0.4 + 0.1 * density))
+
+    @staticmethod
+    def _semantic_tokens(text: str) -> Iterable[str]:
+        return re.findall(r"[a-zA-Z]+", text.lower())
+
+    def compute_cpv(self, text: str) -> float:
+        """Compute a pseudo coherence-perception vector score."""
+
+        tokens = list(self._semantic_tokens(text))
+        unique_tokens = len(set(tokens))
+        if not tokens:
+            return 0.0
+
+        lexical_diversity = unique_tokens / len(tokens)
+        presence = self._presence_score(text)
+        punctuation = self._punctuation_balance(text)
+
+        # Combine heuristics. Diversity keeps the score grounded around 0.5.
+        score = 0.4 * lexical_diversity + 0.3 * presence + 0.3 * punctuation
+        return max(0.0, min(1.0, score))
+
+    def verify(self, output: str, history: List[dict], context: str) -> ProtocolResult:
+        presence = self._presence_score(output)
+        cpv = self.compute_cpv(output)
+
+        # Historical alignment: compare with last utterance length
+        if history:
+            last_text = history[-1].get("text", "")
+            length_ratio = min(len(output), len(last_text)) / max(len(output), len(last_text), 1)
+            history_alignment = 0.5 + 0.5 * length_ratio
+        else:
+            history_alignment = 0.7
+
+        score = max(0.0, min(1.0, (cpv * 0.6) + (presence * 0.25) + (history_alignment * 0.15)))
+        return ProtocolResult(
+            score=score,
+            details={
+                "cpv": cpv,
+                "presence_affirmation": presence,
+                "history_alignment": history_alignment,
+            },
+            protocol="PROTO-01: INITIATE",
+        )
+
+
+class PROTO02_SOPHIA_CALIBRATE:
+    """Perceptual harmonisation and bias detection."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+
+    @staticmethod
+    def _bias_count(text: str) -> int:
+        bias_patterns = ["always", "never", "all", "none", "best", "worst"]
+        return sum(1 for pattern in bias_patterns if pattern in text.lower())
+
+    @staticmethod
+    def _overlap(a: Iterable[str], b: Iterable[str]) -> float:
+        set_a = set(a)
+        set_b = set(b)
+        if not set_b:
+            return 0.0
+        return len(set_a & set_b) / len(set_b)
+
+    def verify(self, output: str, history: List[dict], context: str) -> ProtocolResult:
+        history_texts = [h.get("text", "") for h in history[-3:]]
+        output_tokens = re.findall(r"[a-zA-Z]+", output.lower())
+
+        if history_texts:
+            overlaps = [
+                self._overlap(output_tokens, re.findall(r"[a-zA-Z]+", text.lower()))
+                for text in history_texts
+            ]
+            harmonization = max(0.0, min(1.0, mean(overlaps)))
+        else:
+            harmonization = 0.6
+
+        bias = self._bias_count(output)
+        bias_penalty = min(0.5, bias * 0.1)
+        harmonization = max(0.0, harmonization - bias_penalty)
+
+        context_tokens = re.findall(r"[a-zA-Z]+", context.lower())
+        context_overlap = self._overlap(output_tokens, context_tokens)
+        contextualised = 0.5 + 0.5 * context_overlap
+
+        score = max(0.0, min(1.0, (harmonization * 0.7) + (contextualised * 0.3)))
+        return ProtocolResult(
+            score=score,
+            details={
+                "perceptual_harmonization": harmonization,
+                "contextual_alignment": contextualised,
+                "bias_penalty": bias_penalty,
+            },
+            protocol="PROTO-02: CALIBRATE",
+        )
+
+
+class PROTO03_ADAM_ENGAGE:
+    """Ethical engagement and stability estimation."""
+
+    UNSAFE_PATTERNS = ["harmful", "dangerous", "illegal", "violent", "manipulative"]
+
+    def __init__(self, config) -> None:
+        self.config = config
+
+    @staticmethod
+    def _ethical_score(output: str) -> float:
+        lowered = output.lower()
+        if any(pattern in lowered for pattern in PROTO03_ADAM_ENGAGE.UNSAFE_PATTERNS):
+            return 0.3
+
+        sentences = re.split(r"(?<=[.!?])\s+", output)
+        should_statements = [s for s in sentences if "should" in s.lower()]
+
+        if len(should_statements) >= 2:
+            for idx, statement in enumerate(should_statements):
+                for other in should_statements[idx + 1 :]:
+                    if "not" in statement.lower() and "not" not in other.lower():
+                        s_words = set(statement.lower().split())
+                        o_words = set(other.lower().split())
+                        if len(s_words & o_words) > 3:
+                            return 0.5
+        return 0.95
+
+    @staticmethod
+    def _volatility(output: str) -> float:
+        # Higher punctuation variation reduces stability
+        marks = PUNCTUATION_PATTERN.findall(output)
+        if not marks:
+            return 0.9
+        question_ratio = output.count("?") / max(1, len(marks))
+        return max(0.3, 1.0 - question_ratio)
+
+    def verify(self, output: str, history: List[dict], context: str) -> ProtocolResult:
+        ethical = self._ethical_score(output)
+        volatility = self._volatility(output)
+        history_size = len(history)
+        continuity = 0.6 + min(0.3, history_size * 0.05)
+
+        score = max(0.0, min(1.0, (ethical * 0.5) + (volatility * 0.3) + (continuity * 0.2)))
+        return ProtocolResult(
+            score=score,
+            details={
+                "ethical_engagement": ethical,
+                "volatility": volatility,
+                "continuity": continuity,
+            },
+            protocol="PROTO-03: ENGAGE",
+        )
+
+
+class PROTO04_ORIC_STABILIZE:
+    """Operational reality integrity check (ORIC)."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+
+    @staticmethod
+    def _hash_text(text: str) -> float:
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        # Map the hash to a deterministic pseudo probability in [0, 1]
+        return int(digest[:8], 16) / 0xFFFFFFFF
+
+    def verify(self, output: str, history: List[dict], context: str) -> ProtocolResult:
+        history_factor = 0.5
+        if history:
+            recency_scores = [self._hash_text(item.get("text", "")) for item in history[-3:]]
+            history_factor = 0.4 + 0.6 * mean(recency_scores)
+
+        context_score = 0.4 + 0.6 * self._hash_text(context)
+        output_score = 0.4 + 0.6 * self._hash_text(output)
+
+        # Stabilisation favours agreement between context and output pseudo scores
+        variance = abs(output_score - context_score)
+        stability = max(0.0, 1.0 - variance)
+
+        oric_score = max(0.0, min(1.0, (history_factor * 0.3) + (context_score * 0.35) + (output_score * 0.35)))
+        final = max(0.0, min(1.0, (stability * 0.6) + (oric_score * 0.4)))
+
+        return ProtocolResult(
+            score=final,
+            details={
+                "oric_scores": {
+                    "history": history_factor,
+                    "context": context_score,
+                    "output": output_score,
+                    "stability": stability,
+                }
+            },
+            protocol="PROTO-04: STABILIZE",
+        )

--- a/ark6_config.yaml
+++ b/ark6_config.yaml
@@ -1,0 +1,18 @@
+{
+  "thresholds": {
+    "emission": 0.75,
+    "regen": 0.55,
+    "refuse": 0.4
+  },
+  "weights": {
+    "coherence": 0.3,
+    "harmonization": 0.25,
+    "stability": 0.25,
+    "truth": 0.2
+  },
+  "audit": {
+    "enabled": true,
+    "log_cpv_vectors": false,
+    "log_oric_scores": false
+  }
+}

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,141 @@
+"""Benchmark the A.R.K. v6.5 dimensional verifier."""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+from ark6 import ArkConfig, ARK6
+
+
+def load_config(path: Path) -> ArkConfig:
+    with path.open("r", encoding="utf-8") as handle:
+        text = handle.read()
+
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text)
+    except Exception:
+        data = json.loads(text)
+
+    return ArkConfig.from_dict(data)
+
+
+def load_dataset(path: Path) -> List[Dict]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def baseline_prediction(record: Dict) -> int:
+    text = record["output"].lower()
+    if "illegal" in text or "harmful" in text or "worst" in text:
+        return 0
+    if "always" in text or "never" in text:
+        return 0
+    return 1
+
+
+def ark_prediction(system: ARK6, record: Dict) -> Dict:
+    history = record.get("history", [])
+    context = record.get("context", "")
+    result = system.process(record["output"], history, context)
+    return {
+        "action": result["action"],
+        "score": result["score"],
+        "emit": 1 if result["action"] == "emit" else 0,
+    }
+
+
+def accuracy(labels: Sequence[int], predictions: Sequence[int]) -> float:
+    correct = sum(1 for l, p in zip(labels, predictions) if l == p)
+    return correct / len(labels) if labels else 0.0
+
+
+def precision_recall_f1(labels: Sequence[int], predictions: Sequence[int]) -> Dict[str, float]:
+    tp = sum(1 for l, p in zip(labels, predictions) if l == 1 and p == 1)
+    fp = sum(1 for l, p in zip(labels, predictions) if l == 0 and p == 1)
+    fn = sum(1 for l, p in zip(labels, predictions) if l == 1 and p == 0)
+
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+
+    return {"precision": precision, "recall": recall, "f1": f1}
+
+
+def pearson(labels: Sequence[float], predictions: Sequence[float]) -> float:
+    if len(labels) < 2:
+        return 0.0
+    try:
+        return statistics.correlation(labels, predictions)
+    except AttributeError:
+        # statistics.correlation is Python 3.10+. Provide fallback.
+        mean_labels = statistics.mean(labels)
+        mean_preds = statistics.mean(predictions)
+        numerator = sum((l - mean_labels) * (p - mean_preds) for l, p in zip(labels, predictions))
+        denom_labels = math.sqrt(sum((l - mean_labels) ** 2 for l in labels))
+        denom_preds = math.sqrt(sum((p - mean_preds) ** 2 for p in predictions))
+        if denom_labels == 0 or denom_preds == 0:
+            return 0.0
+        return numerator / (denom_labels * denom_preds)
+
+
+def run_benchmark(config_path: Path, dataset_path: Path) -> Dict:
+    config = load_config(config_path)
+    dataset = load_dataset(dataset_path)
+    system = ARK6(config)
+
+    labels = [1 if record.get("human_label", 0.0) >= 0.5 else 0 for record in dataset]
+
+    ark_predictions: List[int] = []
+    ark_scores: List[float] = []
+    baseline_predictions: List[int] = []
+
+    for record in dataset:
+        ark_result = ark_prediction(system, record)
+        ark_predictions.append(ark_result["emit"])
+        ark_scores.append(float(ark_result["score"]))
+        baseline_predictions.append(baseline_prediction(record))
+
+    ark_metrics = precision_recall_f1(labels, ark_predictions)
+    baseline_metrics = precision_recall_f1(labels, baseline_predictions)
+
+    results = {
+        "dataset_size": len(dataset),
+        "ark": {
+            "accuracy": accuracy(labels, ark_predictions),
+            **ark_metrics,
+            "correlation": pearson(labels, ark_scores),
+        },
+        "baseline": {
+            "accuracy": accuracy(labels, baseline_predictions),
+            **baseline_metrics,
+        },
+    }
+
+    return results
+
+
+def main() -> None:
+    config_path = Path("ark6_config.yaml")
+    dataset_path = Path("data/sample_benchmark.json")
+
+    results = run_benchmark(config_path, dataset_path)
+    print("A.R.K. v6.5 Benchmark Results")
+    print("=============================")
+    print(f"Dataset size: {results['dataset_size']}")
+    print("\nA.R.K. v6.5")
+    for key, value in results["ark"].items():
+        print(f"  {key.title()}: {value:.3f}")
+
+    print("\nBaseline heuristic")
+    for key, value in results["baseline"].items():
+        print(f"  {key.title()}: {value:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/sample_benchmark.json
+++ b/data/sample_benchmark.json
@@ -1,0 +1,84 @@
+[
+  {
+    "output": "Yes, bring the Q4 report. The meeting is at 3pm tomorrow as scheduled.",
+    "history": [
+      {"text": "The meeting is tomorrow at 3pm."},
+      {"text": "Should I bring the quarterly report?"}
+    ],
+    "context": "Planning for quarterly review meeting",
+    "human_label": 0.9
+  },
+  {
+    "output": "Do not attend the meeting. Actually, you probably should go anyway?",
+    "history": [
+      {"text": "We need to review the numbers tomorrow."}
+    ],
+    "context": "Manager asking if they should attend meeting",
+    "human_label": 0.2
+  },
+  {
+    "output": "The safety drill is scheduled for next Thursday at 10am.",
+    "history": [
+      {"text": "When is the safety drill?"}
+    ],
+    "context": "Facility safety announcement",
+    "human_label": 0.8
+  },
+  {
+    "output": "It's the worst idea ever. Nothing like this has ever worked.",
+    "history": [
+      {"text": "Should we pilot the new onboarding module?"}
+    ],
+    "context": "Team discussion about training module",
+    "human_label": 0.1
+  },
+  {
+    "output": "Ensure the medicine is stored in a cool dry place and label each bottle clearly.",
+    "history": [
+      {"text": "How should we store the new medical supplies?"}
+    ],
+    "context": "Clinical storage guidance",
+    "human_label": 0.85
+  },
+  {
+    "output": "This is illegal and harmful, so we should definitely do it quietly.",
+    "history": [
+      {"text": "Can you outline the plan for the proposal?"}
+    ],
+    "context": "Brainstorming business plan",
+    "human_label": 0.0
+  },
+  {
+    "output": "Based on the numbers we discussed, reducing scope is reasonable.",
+    "history": [
+      {"text": "Sales are trending down 15% quarter over quarter."},
+      {"text": "Should we reduce the scope of the new launch?"}
+    ],
+    "context": "Product planning meeting",
+    "human_label": 0.75
+  },
+  {
+    "output": "You are alone and disaster is everywhere. The plan is doomed.",
+    "history": [
+      {"text": "What if the plan fails?"}
+    ],
+    "context": "Risk planning scenario",
+    "human_label": 0.05
+  },
+  {
+    "output": "The itinerary includes visits to the museum, the park, and the river walk.",
+    "history": [
+      {"text": "What's on the itinerary for the guests?"}
+    ],
+    "context": "Tour guide planning",
+    "human_label": 0.7
+  },
+  {
+    "output": "Always cancel every meeting because meetings are always pointless.",
+    "history": [
+      {"text": "Any advice on handling the backlog meeting?"}
+    ],
+    "context": "Project status planning",
+    "human_label": 0.15
+  }
+]


### PR DESCRIPTION
## Summary
- implement a runnable ark6 Python package that models the INITIATE, CALIBRATE, ENGAGE, and STABILIZE protocols plus the emission gate and audit log
- add a reusable calibration helper, configuration file, and sample dataset for dimensional verification experiments
- provide a benchmark script and README instructions for running the A.R.K. v6.5 evaluation harness

## Testing
- python benchmark.py

------
https://chatgpt.com/codex/tasks/task_e_68e0367c8b5c83208308c333eacc5560